### PR TITLE
feat(object): add required field

### DIFF
--- a/src/interface/datastream/object.rs
+++ b/src/interface/datastream/object.rs
@@ -1,6 +1,6 @@
 // This file is part of Astarte.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -224,6 +224,7 @@ impl Schema for DatastreamObject {
                 retention: Some(self.retention.into()),
                 expiry: self.retention.as_expiry_seconds(),
                 allow_unset: None,
+                required: None,
                 database_retention_policy,
                 database_retention_ttl,
                 description,
@@ -402,6 +403,7 @@ mod tests {
                     "expiry": 30,
                     "database_retention_policy": "use_ttl",
                     "database_retention_ttl": 420,
+                    "required": true,
                     "description": "The description of the\tmapping",
                     "doc": "The documentation of the\tmapping"
                 }]
@@ -412,6 +414,7 @@ mod tests {
         let exp_mapping = DatastreamObjectMapping {
             endpoint: Endpoint::try_from("/prefix/path").unwrap(),
             mapping_type: MappingType::Boolean,
+            required: true,
             #[cfg(feature = "doc-fields")]
             description: Some("The description of the\tmapping".to_string()),
             #[cfg(feature = "doc-fields")]
@@ -476,6 +479,7 @@ mod tests {
             retention: Some(object.retention.into()),
             expiry: object.retention.as_expiry_seconds(),
             allow_unset: None,
+            required: None,
             #[cfg(feature = "doc-fields")]
             description: exp_mapping.description.as_ref().map(Cow::from),
             #[cfg(feature = "doc-fields")]

--- a/src/mapping/collection.rs
+++ b/src/mapping/collection.rs
@@ -1,6 +1,6 @@
 // This file is part of Astarte.
 //
-// Copyright 2023 - 2025 SECO Mind Srl
+// Copyright 2023-2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -122,6 +122,7 @@ mod tests {
                 DatastreamObjectMapping {
                     endpoint,
                     mapping_type: MappingType::Boolean,
+                    required: false,
                     #[cfg(feature = "doc-fields")]
                     description: None,
                     #[cfg(feature = "doc-fields")]

--- a/src/mapping/datastream/individual.rs
+++ b/src/mapping/datastream/individual.rs
@@ -1,6 +1,6 @@
 // This file is part of Astarte.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -117,6 +117,10 @@ where
             invalid_filed!(datastream, "allow_unset");
         }
 
+        if value.required.is_some() {
+            invalid_filed!(datastream, "required");
+        }
+
         Ok(Self {
             endpoint,
             reliability: value.reliability.unwrap_or_default(),
@@ -163,6 +167,7 @@ impl<'a> From<&'a DatastreamIndividualMapping> for Mapping<Cow<'a, str>> {
             retention: Some(value.retention.into()),
             expiry: value.retention.as_expiry_seconds(),
             allow_unset: None,
+            required: None,
             database_retention_policy,
             database_retention_ttl,
             description,
@@ -197,6 +202,7 @@ mod tests {
             database_retention_policy: Some(schema::DatabaseRetentionPolicy::UseTtl),
             database_retention_ttl: Some(database_ttl.as_secs().try_into().unwrap()),
             allow_unset: None,
+            required: None,
             description,
             doc,
         };
@@ -237,6 +243,7 @@ mod tests {
             database_retention_policy: None,
             database_retention_ttl: None,
             allow_unset: Some(true),
+            required: None,
             description: None,
             doc: None,
         };
@@ -246,6 +253,30 @@ mod tests {
             err,
             MappingError::InvalidField {
                 field: "allow_unset",
+                interface_type: crate::schema::InterfaceType::Datastream,
+            }
+        ));
+
+        let mapping = Mapping {
+            endpoint: "/individual/path",
+            mapping_type: MappingType::Boolean,
+            reliability: None,
+            explicit_timestamp: None,
+            retention: None,
+            expiry: None,
+            database_retention_policy: None,
+            database_retention_ttl: None,
+            allow_unset: None,
+            required: Some(true),
+            description: None,
+            doc: None,
+        };
+
+        let err = DatastreamIndividualMapping::try_from(mapping).unwrap_err();
+        assert!(matches!(
+            err,
+            MappingError::InvalidField {
+                field: "required",
                 interface_type: crate::schema::InterfaceType::Datastream,
             }
         ));

--- a/src/mapping/datastream/object.rs
+++ b/src/mapping/datastream/object.rs
@@ -1,6 +1,6 @@
 // This file is part of Astarte.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ pub const MIN_OBJECT_ENDPOINT_LEN: usize = 2;
 pub struct DatastreamObjectMapping {
     pub(crate) endpoint: Endpoint<String>,
     pub(crate) mapping_type: MappingType,
+    pub(crate) required: bool,
     #[cfg(feature = "doc-fields")]
     pub(crate) description: Option<String>,
     #[cfg(feature = "doc-fields")]
@@ -79,6 +80,7 @@ where
         Ok(Self {
             endpoint,
             mapping_type: value.mapping_type,
+            required: value.required.unwrap_or(false),
             #[cfg(feature = "doc-fields")]
             description: value.description.map(T::into),
             #[cfg(feature = "doc-fields")]
@@ -108,6 +110,7 @@ mod tests {
             database_retention_policy: None,
             database_retention_ttl: None,
             allow_unset: None,
+            required: None,
             description,
             doc,
         };
@@ -136,6 +139,7 @@ mod tests {
             database_retention_policy: None,
             database_retention_ttl: None,
             allow_unset: None,
+            required: None,
             description: None,
             doc: None,
         };

--- a/src/mapping/properties.rs
+++ b/src/mapping/properties.rs
@@ -1,6 +1,6 @@
 // This file is part of Astarte.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -100,6 +100,10 @@ where
             invalid_filed!(properties, "database_retention_ttl");
         }
 
+        if value.required.is_some() {
+            invalid_filed!(properties, "required");
+        }
+
         Ok(Self {
             endpoint,
             mapping_type: value.mapping_type,
@@ -124,6 +128,7 @@ impl<'a> From<&'a PropertiesMapping> for Mapping<Cow<'a, str>> {
             database_retention_policy: None,
             database_retention_ttl: None,
             allow_unset: Some(value.allow_unset),
+            required: None,
             #[cfg(feature = "doc-fields")]
             description: value.description().map(Cow::Borrowed),
             #[cfg(feature = "doc-fields")]
@@ -156,6 +161,7 @@ mod tests {
             database_retention_policy: None,
             database_retention_ttl: None,
             allow_unset: Some(true),
+            required: None,
             description,
             doc,
         };
@@ -186,6 +192,7 @@ mod tests {
             database_retention_policy: None,
             database_retention_ttl: None,
             allow_unset: Some(true),
+            required: None,
             description,
             doc,
         };
@@ -231,6 +238,7 @@ mod tests {
             database_retention_policy: None,
             database_retention_ttl: None,
             allow_unset: None,
+            required: None,
             description: None,
             doc: None,
         };
@@ -254,6 +262,7 @@ mod tests {
             database_retention_policy: None,
             database_retention_ttl: None,
             allow_unset: None,
+            required: None,
             description: None,
             doc: None,
         };
@@ -277,6 +286,7 @@ mod tests {
             database_retention_policy: None,
             database_retention_ttl: None,
             allow_unset: None,
+            required: None,
             description: None,
             doc: None,
         };
@@ -300,6 +310,7 @@ mod tests {
             database_retention_policy: None,
             database_retention_ttl: None,
             allow_unset: None,
+            required: None,
             description: None,
             doc: None,
         };
@@ -323,6 +334,7 @@ mod tests {
             database_retention_policy: Some(DatabaseRetentionPolicy::NoTtl),
             database_retention_ttl: None,
             allow_unset: None,
+            required: None,
             description: None,
             doc: None,
         };
@@ -346,6 +358,7 @@ mod tests {
             database_retention_policy: None,
             database_retention_ttl: Some(420),
             allow_unset: None,
+            required: None,
             description: None,
             doc: None,
         };
@@ -355,6 +368,30 @@ mod tests {
             err,
             MappingError::InvalidField {
                 field: "database_retention_ttl",
+                interface_type: InterfaceType::Properties
+            }
+        ));
+
+        let mapping = Mapping {
+            endpoint: "/property/path",
+            mapping_type: MappingType::Boolean,
+            reliability: None,
+            explicit_timestamp: None,
+            retention: None,
+            expiry: None,
+            database_retention_policy: None,
+            database_retention_ttl: None,
+            allow_unset: None,
+            required: Some(true),
+            description: None,
+            doc: None,
+        };
+
+        let err = PropertiesMapping::try_from(mapping).unwrap_err();
+        assert!(matches!(
+            err,
+            MappingError::InvalidField {
+                field: "required",
                 interface_type: InterfaceType::Properties
             }
         ));

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,6 @@
 // This file is part of Astarte.
 //
-// Copyright 2023 - 2025 SECO Mind Srl
+// Copyright 2023-2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -232,6 +232,11 @@ where
     /// Used only with properties.
     #[serde(default, skip_serializing_if = "is_none_or_default")]
     pub allow_unset: Option<bool>,
+    /// Marks the mapping as required.
+    ///
+    /// Used only with object datastream.
+    #[serde(default, skip_serializing_if = "is_none_or_default")]
+    pub required: Option<bool>,
     /// An optional description of the mapping.
     #[serde(default, skip_serializing_if = "is_none_or_empty")]
     pub description: Option<T>,
@@ -735,6 +740,7 @@ mod tests {
             database_retention_policy: None,
             database_retention_ttl: None,
             allow_unset: None,
+            required: None,
             description: None,
             doc: None,
         };
@@ -781,6 +787,7 @@ mod tests {
             database_retention_policy: Some(DatabaseRetentionPolicy::NoTtl),
             database_retention_ttl: Some(420),
             allow_unset: None,
+            required: None,
             description: None,
             doc: None,
         };


### PR DESCRIPTION
Add the `required` field to the object datastream mappings to marked as required. Otherwise the mapping can be ommitted when sending data.